### PR TITLE
Cron does nothing without the service running

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,3 +57,4 @@ COPY ./default_crontab /home/
 RUN crontab /home/default_crontab
 
 CMD service php7.2-fpm start && service redis-server start && nginx -g "daemon off;"
+CMD service cron start


### PR DESCRIPTION
I made the default cronjob for pathfinder but forgot to actually turn it on....

not 100% sure about the docker way to do this so I tried to mimic the current dockerfile.